### PR TITLE
Fix stemming for kurutma and ledli

### DIFF
--- a/src/main/resources/org/elasticsearch/index/analysis/average_stem_size_exceptions.txt
+++ b/src/main/resources/org/elasticsearch/index/analysis/average_stem_size_exceptions.txt
@@ -54,3 +54,4 @@ uç
 uygun
 var
 yasa
+led

--- a/src/main/resources/org/elasticsearch/index/analysis/average_stem_size_exceptions.txt
+++ b/src/main/resources/org/elasticsearch/index/analysis/average_stem_size_exceptions.txt
@@ -55,3 +55,4 @@ uygun
 var
 yasa
 led
+gaz

--- a/src/main/resources/org/elasticsearch/index/analysis/last_consonant_exceptions.txt
+++ b/src/main/resources/org/elasticsearch/index/analysis/last_consonant_exceptions.txt
@@ -1,3 +1,4 @@
 ad
 at
 ked
+led

--- a/src/main/resources/org/elasticsearch/index/analysis/protected_words.txt
+++ b/src/main/resources/org/elasticsearch/index/analysis/protected_words.txt
@@ -157,3 +157,4 @@ yasa
 yıldız
 zayıflama
 zemin
+kurutma

--- a/src/test/resources/stemming_samples.txt
+++ b/src/test/resources/stemming_samples.txt
@@ -6147,10 +6147,10 @@ gazetelik,gazetelik
 gazetesi,gazete
 gazi,gazi
 gaziantep,gaziantep
-gazla,gazl
+gazla,gaz
 gazli,gazli
 gazlli,gazlli
-gazlı,gazl
+gazlı,gaz
 gazyagı,gazyag
 gazzaro,gazzaro
 gaıaksi,gaıaksi

--- a/src/test/resources/stemming_samples.txt
+++ b/src/test/resources/stemming_samples.txt
@@ -9001,7 +9001,7 @@ kurulması,kurulma
 kurulum,kurul
 kurulumu,kurul
 kurutceporno,kurutceporno
-kurutma,kurut
+kurutma,kurutma
 kurutmali,kurutmali
 kurutmalı,kurutma
 kurutucu,kurutuç
@@ -9300,8 +9300,8 @@ lecoste,lecoste
 lecoultre,lecoultre
 led,led
 lede,le
-ledler,let
-ledli,ledl
+ledler,led
+ledli,led
 ledsadece,ledsade
 ledtoplar,ledtop
 ledtv,ledtv


### PR DESCRIPTION
ledli:
- last consonant exception prevents `led` -> `let` (since it's not a
  native  turkish word it makes sense to ignore the harmony rule)
- selection list exceptions prevents stem candidates other than `led`
  to be selected

kurutma:
 There is no specific exception list for the `noun_suffix_machine` which
 creates the `kurutm` and `kurut` candidates, so this term was put in
 `protected` words.
