### PR TITLE
Update for 2.x.x series

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,6 @@
 		</dependency>
 
 		<dependency>
-		    <groupId>com.google.guava</groupId>
-		    <artifactId>guava</artifactId>
-		    <version>16.0.1</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,9 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<elasticsearch.version>1.5.0</elasticsearch.version>
+		<elasticsearch.version>2.4.4</elasticsearch.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<developers>
@@ -125,7 +127,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>1.7</version>
+                  <version>${maven.compiler.target}</version>
                 </requireJavaVersion>
               </rules>
             </configuration>
@@ -137,10 +139,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -16,4 +16,14 @@
             </excludes>
         </dependencySet>
     </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/resources/</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>*.properties</include>
+            </includes>
+            <filtered>true</filtered>
+        </fileSet>
+    </fileSets>
 </assembly>

--- a/src/main/java/org/elasticsearch/index/analysis/TurkishStemmer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/TurkishStemmer.java
@@ -16,10 +16,8 @@ import org.apache.commons.lang3.StringUtils; // Apache StringUtils
 import org.apache.lucene.analysis.util.CharArraySet;
 import org.apache.lucene.analysis.util.WordlistLoader;
 import org.apache.lucene.util.IOUtils;
-import org.apache.lucene.util.Version;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.analysis.stemmer.turkish.states.DerivationalState;
 import org.elasticsearch.index.analysis.stemmer.turkish.states.NominalVerbState;
 import org.elasticsearch.index.analysis.stemmer.turkish.states.NounState;
@@ -645,20 +643,17 @@ public class TurkishStemmer {
    *
    * @param stopwords
    *          Input stream from the stopwords file
-   *
-   * @param matchVersion
-   *          the Lucene version for cross version compatibility
    * @return a CharArraySet containing the distinct stopwords from the given
    *         file
    * @throws IOException
    *           if loading the stopwords throws an {@link IOException}
    */
-  private static CharArraySet loadWordSet(InputStream file, Version matchVersion)
+  private static CharArraySet loadWordSet(InputStream file)
       throws IOException {
     Reader reader = null;
     try {
       reader = IOUtils.getDecodingReader(file, StandardCharsets.UTF_8);
-      return WordlistLoader.getWordSet(reader, matchVersion);
+      return WordlistLoader.getWordSet(reader);
     } finally {
       IOUtils.close(reader);
     }
@@ -674,8 +669,7 @@ public class TurkishStemmer {
       try {
         DEFAULT_PROTECTED_WORDS = loadWordSet(
             TurkishStemmer.class
-                .getResourceAsStream(DEFAULT_PROTECTED_WORDS_FILE),
-            Lucene.VERSION);
+                .getResourceAsStream(DEFAULT_PROTECTED_WORDS_FILE));
       } catch(IOException ex) {
         throw new RuntimeException("Unable to load default protected words");
       }
@@ -683,8 +677,7 @@ public class TurkishStemmer {
       try {
         DEFAULT_VOWEL_HARMONY_EXCEPTIONS = loadWordSet(
             TurkishStemmer.class
-                .getResourceAsStream(DEFAULT_VOWEL_HARMONY_EXCEPTIONS_FILE),
-            Lucene.VERSION);
+                .getResourceAsStream(DEFAULT_VOWEL_HARMONY_EXCEPTIONS_FILE));
       } catch(IOException ex) {
         throw new RuntimeException(
             "Unable to load default vowel harmony exceptions");
@@ -693,8 +686,7 @@ public class TurkishStemmer {
       try {
         DEFAULT_LAST_CONSONANT_EXCEPTIONS = loadWordSet(
             TurkishStemmer.class
-                .getResourceAsStream(DEFAULT_LAST_CONSONANT_EXCEPTIONS_FILE),
-            Lucene.VERSION);
+                .getResourceAsStream(DEFAULT_LAST_CONSONANT_EXCEPTIONS_FILE));
       } catch(IOException ex) {
         throw new RuntimeException(
             "Unable to load default vowel harmony exceptions");
@@ -703,8 +695,7 @@ public class TurkishStemmer {
       try {
         DEFAULT_AVERAGE_STEM_SIZE_EXCEPTIONS = loadWordSet(
             TurkishStemmer.class
-                .getResourceAsStream(DEFAULT_AVERAGE_STEM_SIZE_EXCEPTION_FILE),
-            Lucene.VERSION);
+                .getResourceAsStream(DEFAULT_AVERAGE_STEM_SIZE_EXCEPTION_FILE));
       } catch(IOException ex) {
         throw new RuntimeException(
             "Unable to load default average stem size exceptions");

--- a/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilterFactory.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.FailedToResolveConfigException;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.settings.IndexSettings;
+import org.elasticsearch.index.settings.IndexSettingsService;
 
 public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory {
 
@@ -25,11 +25,11 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
 
   @Inject
   public TurkishStemmerTokenFilterFactory(Index index,
-      @IndexSettings Settings indexSettings,
+      IndexSettingsService indexSettings,
       Environment env, @Assisted String name,
       @Assisted Settings settings) {
 
-    super(index, indexSettings, name, settings);
+    super(index, indexSettings.getSettings(), name, settings);
     this.protectedWords = parseProtectedWords(env, settings,
         "protected_words_path");
     this.vowelHarmonyExceptions = parseVowelHarmonyExceptions(env, settings,

--- a/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilterFactory.java
@@ -2,6 +2,7 @@ package org.elasticsearch.index.analysis;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +12,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.env.FailedToResolveConfigException;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.settings.IndexSettingsService;
 
@@ -132,7 +132,7 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
 
     try {
       exceptionsReader = Analysis.getReaderFromFile(env, settings, settingPrefix);
-    } catch (FailedToResolveConfigException e) {
+    } catch (InvalidPathException e) {
       logger.info("failed to find the " + settingPrefix + ", using the default set");
     }
 

--- a/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilterFactory.java
@@ -7,10 +7,8 @@ import java.util.List;
 
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.util.CharArraySet;
-import org.apache.lucene.util.Version;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.assistedinject.Assisted;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.FailedToResolveConfigException;
@@ -33,13 +31,13 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
 
     super(index, indexSettings, name, settings);
     this.protectedWords = parseProtectedWords(env, settings,
-        "protected_words_path", Lucene.VERSION);
+        "protected_words_path");
     this.vowelHarmonyExceptions = parseVowelHarmonyExceptions(env, settings,
-        "vowel_harmony_exceptions_path", Lucene.VERSION);
+        "vowel_harmony_exceptions_path");
     this.lastConsonantExceptions = parseLastConsonantExceptions(env, settings,
-        "last_consonant_exceptions_path", Lucene.VERSION);
+        "last_consonant_exceptions_path");
     this.averageStemSizeExceptions = parseAverageStemSizeExceptions(env, settings,
-        "average_stem_size_exceptions_path", Lucene.VERSION);
+        "average_stem_size_exceptions_path");
   }
 
   @Override
@@ -52,12 +50,12 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
   }
 
   private CharArraySet parseProtectedWords(Environment env, Settings settings,
-      String settingPrefix, Version version) {
+      String settingPrefix) {
 
     CharArraySet protectedWords = null;
 
     try{
-      protectedWords = parseExceptions(env, settings, settingPrefix, version);
+      protectedWords = parseExceptions(env, settings, settingPrefix);
     } catch(IOException e) {
       logger.info("Failed to load given protected words, using default set");
     }
@@ -70,13 +68,13 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
   }
 
   private CharArraySet parseLastConsonantExceptions(Environment env,
-      Settings settings, String settingPrefix, Version version) {
+      Settings settings, String settingPrefix) {
 
     CharArraySet lastConsonantExceptions = null;
 
     try {
       lastConsonantExceptions =
-          parseExceptions(env, settings, settingPrefix, version);
+          parseExceptions(env, settings, settingPrefix);
     } catch (IOException e) {
       logger.info("Failed to load given last consonant exceptions, using default set");
     }
@@ -89,13 +87,13 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
   }
 
   private CharArraySet parseVowelHarmonyExceptions(Environment env,
-      Settings settings, String settingPrefix, Version version) {
+      Settings settings, String settingPrefix) {
 
     CharArraySet vowelHarmonyExceptions = null;
 
     try {
       vowelHarmonyExceptions =
-          parseExceptions(env, settings, settingPrefix, version);
+          parseExceptions(env, settings, settingPrefix);
     } catch (IOException e) {
       logger.info("Failed to load given last consonant exceptions, using default set");
     }
@@ -108,13 +106,13 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
   }
 
   private CharArraySet parseAverageStemSizeExceptions(Environment env,
-      Settings settings, String settingPrefix, Version version) {
+      Settings settings, String settingPrefix) {
 
     CharArraySet averageStemSizeExceptions = null;
 
     try {
       averageStemSizeExceptions =
-          parseExceptions(env, settings, settingPrefix, version);
+          parseExceptions(env, settings, settingPrefix);
     } catch (IOException e) {
       logger.info("Failed to load given average stem size exceptions, using default set");
     }
@@ -127,7 +125,7 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
   }
 
   private CharArraySet parseExceptions(Environment env, Settings settings,
-      String settingPrefix, Version version) throws IOException {
+      String settingPrefix) throws IOException {
 
     List<String> exceptionsList = new ArrayList<String>();
     Reader exceptionsReader = null;
@@ -144,7 +142,7 @@ public class TurkishStemmerTokenFilterFactory extends AbstractTokenFilterFactory
         if (exceptionsList.isEmpty()) {
           return CharArraySet.EMPTY_SET;
         } else {
-          return new CharArraySet(version, exceptionsList, false);
+          return new CharArraySet(exceptionsList, false);
         }
       } finally {
         if (exceptionsReader != null)

--- a/src/main/java/org/elasticsearch/plugin/analysis/turkishstemmer/TurkishStemmerPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/analysis/turkishstemmer/TurkishStemmerPlugin.java
@@ -2,9 +2,9 @@ package org.elasticsearch.plugin.analysis.turkishstemmer;
 
 import org.elasticsearch.index.analysis.AnalysisModule;
 import org.elasticsearch.index.analysis.TurkishStemmerBinderProcessor;
-import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.plugins.Plugin;
 
-public class TurkishStemmerPlugin extends AbstractPlugin {
+public class TurkishStemmerPlugin extends Plugin {
 
   @Override
   public String description() {

--- a/src/main/resources/es-plugin.properties
+++ b/src/main/resources/es-plugin.properties
@@ -1,2 +1,0 @@
-plugin=org.elasticsearch.plugin.analysis.turkishstemmer.TurkishStemmerPlugin
-version=${project.version}

--- a/src/main/resources/plugin-descriptor.properties
+++ b/src/main/resources/plugin-descriptor.properties
@@ -1,0 +1,8 @@
+name=${project.name}
+description=${project.description}
+version=${project.version}
+
+jvm=true
+java.version=${maven.compiler.target}
+elasticsearch.version=${elasticsearch.version}
+classname=org.elasticsearch.plugin.analysis.turkishstemmer.TurkishStemmerPlugin

--- a/src/test/java/org/elasticsearch/index/analysis/SimpleTurkishStemmerAnalysisTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/SimpleTurkishStemmerAnalysisTest.java
@@ -13,10 +13,9 @@ import org.elasticsearch.env.EnvironmentModule;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNameModule;
 import org.elasticsearch.index.settings.IndexSettingsModule;
-import org.elasticsearch.indices.analysis.IndicesAnalysisModule;
 import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 
-import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
+import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class SimpleTurkishStemmerAnalysisTest {
@@ -26,12 +25,14 @@ public class SimpleTurkishStemmerAnalysisTest {
       Index index = new Index("test");
 
       Settings indexSettings = settingsBuilder()
-          .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT).build();
+          .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+          .put("path.home", "/")
+          .build();
 
       Injector parentInjector = new ModulesBuilder()
           .add(new SettingsModule(indexSettings),
-               new EnvironmentModule(new Environment(indexSettings)),
-               new IndicesAnalysisModule()).createInjector();
+               new EnvironmentModule(new Environment(indexSettings)))
+          .createInjector();
 
       Injector injector = new ModulesBuilder()
           .add(new IndexSettingsModule(index, indexSettings),


### PR DESCRIPTION
This branch updates the plugin that is currently compatible with elasticsearch 1.5.2 (lucene 4.10.4), to the latest stable version of the 2.x.x series.
The reason is that we might need this step in production before upgrading directly to 5.x.x series, but it's also easier to upgrade the plugin in steps.

Right now the latest stable elasticsearch version in the 2.x.x series is 2.4.4 (lucene 5.5.2).
Also note that java 8 is required (up from 7).