### PR TITLE
Correct spelling mistakes with words ending with u or i

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/TurkishStemmer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/TurkishStemmer.java
@@ -184,6 +184,35 @@ public class TurkishStemmer {
     wordsToStem = new HashSet<String>(stems);
     wordsToStem.add(originalWord);
 
+    // If it's not a protected word
+    if (!protectedWords.contains(String.valueOf(s))) {
+      // and none of the stemming rules matches
+      if (stems.size() == 0) {
+        char lastLetter = s[s.length - 1];
+        if(lastLetter == 'u' || lastLetter == 'ü' || lastLetter == 'i' ||
+                lastLetter == 'ı') {
+          // if it's a u replace it with ü and vice versa
+          if (lastLetter == 'u') {
+            s[s.length - 1] = 'ü';
+          } else if (lastLetter == 'ü') {
+            s[s.length - 1] = 'u';
+            // if it's a i replace it with ı and vice versa
+          } else if (lastLetter == 'i') {
+            s[s.length - 1] = 'ı';
+          } else if (lastLetter == 'ı') {
+            s[s.length - 1] = 'i';
+          }
+
+          // and try stemming again - hopefully it will find a match this time
+          // recursive call - beware!
+          // TODO: add an argument to restrict number of potential calls in order
+          // to avoid worst case scenario -> stack overflow
+          // TODO: check if there are other cases we need to consider e.g.
+          // vowel harmony
+          return stem(s, len);
+        }
+      }
+    }
     for(String word : wordsToStem) {
       // Process each possible stem with the derivational suffix state machine.
       derivationalSuffixStripper(word, stems);

--- a/src/test/java/org/elasticsearch/index/analysis/TurkishStemmerTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/TurkishStemmerTest.java
@@ -41,7 +41,9 @@ public class TurkishStemmerTest {
       { "aparatı", "aparat" },
       { "arada", "ara" },
       { "arasındaki", "ara" },
-      { "gozluklerinde", "gozluk" }
+      { "gozluklerinde", "gozluk" },
+      { "monitörü", "monitör" },
+      { "monitöru", "monitör" }
     };
   }
 


### PR DESCRIPTION
For simplicity some Alve users type `monitöru` instead of its accented version: `monitörü`. This causes various problems, with `monitöru` redirecting luckily to an SKU because of a product name, while `monitörü` redirects to an SKU list.

The current rule applied is that if a word has not been stemmed and it's not an exception and ends with u, ü, ı or i, replace u with ü (and vice versa), or ı with i (and vice versa).  