### PR TITLE
#21 elasticsearch-analysis-turkishstemmer can't be used when asserts …

### DIFF
--- a/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/TurkishStemmerTokenFilter.java
@@ -27,7 +27,7 @@ public class TurkishStemmerTokenFilter extends TokenFilter {
   }
 
   @Override
-  public boolean incrementToken() throws IOException {
+  public final boolean incrementToken() throws IOException {
     String stem;
 
     if (input.incrementToken()) {


### PR DESCRIPTION
…are enabled in Lucene (using Elasticsearch)